### PR TITLE
Add set_kd_mode_ex to allow setting mode from non-interactive session 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "framebuffer"
 version = "0.1.7"
 authors = ["Roy van der Vegt <royvandervegt@gmail.com>"]
+edition = "2018"
 description = """
 Basic framebuffer abstraction. Handles the necessary ioctls and mmaps the framebuffer device.
 """

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,4 @@ path = "examples/sierpinski/main.rs"
 
 [dev_dependencies]
 bmp = "0.1.4"
-rand = "0.3.12"
+rand = "0.6"

--- a/examples/rust-logo/main.rs
+++ b/examples/rust-logo/main.rs
@@ -15,7 +15,7 @@ fn main() {
     let img = bmp::open("examples/rust-logo/rust-logo.bmp").unwrap();
 
     //Disable text mode in current tty
-    let _ = Framebuffer::set_kd_mode_ex("/dev/console", KdMode::Graphics).unwrap();
+    let _ = Framebuffer::set_kd_mode(KdMode::Graphics).unwrap();
 
     for offset in 0..w - img.get_width() {
         for (x, y) in img.coordinates() {
@@ -30,5 +30,5 @@ fn main() {
     }
 
     //Reenable text mode in current tty
-    let _ = Framebuffer::set_kd_mode_ex("/dev/console", KdMode::Text).unwrap();
+    let _ = Framebuffer::set_kd_mode(KdMode::Text).unwrap();
 }

--- a/examples/rust-logo/main.rs
+++ b/examples/rust-logo/main.rs
@@ -15,7 +15,7 @@ fn main() {
     let img = bmp::open("examples/rust-logo/rust-logo.bmp").unwrap();
 
     //Disable text mode in current tty
-    let _ = Framebuffer::set_kd_mode(KdMode::Graphics).unwrap();
+    let _ = Framebuffer::set_kd_mode_ex("/dev/console", KdMode::Graphics).unwrap();
 
     for offset in 0..w - img.get_width() {
         for (x, y) in img.coordinates() {
@@ -30,5 +30,5 @@ fn main() {
     }
 
     //Reenable text mode in current tty
-    let _ = Framebuffer::set_kd_mode(KdMode::Text).unwrap();
+    let _ = Framebuffer::set_kd_mode_ex("/dev/console", KdMode::Text).unwrap();
 }

--- a/examples/starfield/main.rs
+++ b/examples/starfield/main.rs
@@ -84,10 +84,10 @@ impl Star {
         let hh = h as f32 / 4.0;
 
         let mut rng = rand::thread_rng();
-        self.x = rng.gen_range::<f32>(-wh, wh);
-        self.b = rng.gen_range::<f32>(-hh, hh);
+        self.x = rng.gen_range(-wh, wh);
+        self.b = rng.gen_range(-hh, hh);
         self.a = self.b / self.x;
-        self.z = rng.gen_range::<f32>(1.0, 1.001);
+        self.z = rng.gen_range(1.0, 1.001);
     }
 
     fn get_pos(&self, w: usize, h: usize) -> (usize, usize) {
@@ -112,7 +112,7 @@ impl Star {
 fn main() {
     let mut framebuffer = Framebuffer::new("/dev/fb0").unwrap();
 
-    let w = framebuffer.var_screen_info.xres;
+    let _w = framebuffer.var_screen_info.xres;
     let h = framebuffer.var_screen_info.yres;
     let line_length = framebuffer.fix_screen_info.line_length;
     let mut frame = vec![0u8; (line_length * h) as usize];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,15 +165,13 @@ pub struct Framebuffer {
 
 impl Framebuffer {
     pub fn new<P: AsRef<Path>>(path_to_device: P) -> Result<Framebuffer, FramebufferError> {
-        let device = try!(
-            OpenOptions::new()
+        let device = OpenOptions::new()
                 .read(true)
                 .write(true)
-                .open(path_to_device)
-        );
+                .open(path_to_device)?;
 
-        let var_screen_info = try!(Framebuffer::get_var_screeninfo(&device));
-        let fix_screen_info = try!(Framebuffer::get_fix_screeninfo(&device));
+        let var_screen_info = Framebuffer::get_var_screeninfo(&device)?;
+        let fix_screen_info = Framebuffer::get_fix_screeninfo(&device)?;
 
         let frame_length = (fix_screen_info.line_length * var_screen_info.yres) as usize;
         let frame = Mmap::open_with_offset(&device, Protection::ReadWrite, 0, frame_length);
@@ -257,12 +255,10 @@ impl Framebuffer {
         path_to_device: P,
         kd_mode: KdMode
     ) -> Result<i32, FramebufferError> {
-        let device = try!(
-            OpenOptions::new()
+        let device = OpenOptions::new()
                 .read(true)
                 .write(true)
-                .open(path_to_device)
-        );
+                .open(path_to_device)?;
 
         match unsafe { ioctl(device.as_raw_fd(), KDSETMODE, kd_mode) } {
             -1 => Err(FramebufferError::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,4 +251,25 @@ impl Framebuffer {
             ret => Ok(ret),
         }
     }
+
+    /// Allows setting tty mode from non-terminal session by explicitly specifying device name
+    pub fn set_kd_mode_ex<P: AsRef<Path>>(
+        path_to_device: P,
+        kd_mode: KdMode
+    ) -> Result<i32, FramebufferError> {
+        let device = try!(
+            OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(path_to_device)
+        );
+
+        match unsafe { ioctl(device.as_raw_fd(), KDSETMODE, kd_mode) } {
+            -1 => Err(FramebufferError::new(
+                FramebufferErrorKind::IoctlFailed,
+                "Ioctl returned -1",
+            )),
+            ret => Ok(ret),
+        }
+    }
 }


### PR DESCRIPTION
I've added set_kd_mode_ex which works the same as original function, but allows to specify device name. This is required to use framebuffer from non-interactive sessions like daemons.
Also I've updated project to 2018 edition in separate commit.
