### PR TITLE
fixed double reference in put_var_screeninfo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ impl Framebuffer {
         device: &File,
         screeninfo: &VarScreeninfo,
     ) -> Result<i32, FramebufferError> {
-        match unsafe { ioctl(device.as_raw_fd(), FBIOPUT_VSCREENINFO as _, &screeninfo) } {
+        match unsafe { ioctl(device.as_raw_fd(), FBIOPUT_VSCREENINFO as _, screeninfo) } {
             -1 => Err(FramebufferError::new(
                 FramebufferErrorKind::IoctlFailed,
                 "Ioctl returned -1",


### PR DESCRIPTION
Took me some time to figure out why `put_var_screeninfo` calls always failed with EINVAL or EPERM - Bugs in Rust love to hide in unsafe blocks :)