### PR TITLE
Add support for full virtual resolution and framebuffer panning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ use memmap::{MmapMut, MmapOptions};
 const FBIOGET_VSCREENINFO: libc::c_ulong = 0x4600;
 const FBIOPUT_VSCREENINFO: libc::c_ulong = 0x4601;
 const FBIOGET_FSCREENINFO: libc::c_ulong = 0x4602;
+const FBIOPAN_DISPLAY: libc::c_ulong = 0x4606;
 
 const KDSETMODE: libc::c_ulong = 0x4B3A;
 const KD_TEXT: libc::c_ulong = 0x00;
@@ -229,6 +230,19 @@ impl Framebuffer {
         screeninfo: &VarScreeninfo,
     ) -> Result<i32, FramebufferError> {
         match unsafe { ioctl(device.as_raw_fd(), FBIOPUT_VSCREENINFO as _, screeninfo) } {
+            -1 => Err(FramebufferError::new(
+                FramebufferErrorKind::IoctlFailed,
+                &format!("Ioctl returned -1: {}", errno()),
+            )),
+            ret => Ok(ret),
+        }
+    }
+
+    pub fn pan_display(
+        device: &File,
+        screeninfo: &VarScreeninfo,
+    ) -> Result<i32, FramebufferError> {
+        match unsafe { ioctl(device.as_raw_fd(), FBIOPAN_DISPLAY as _, screeninfo) } {
             -1 => Err(FramebufferError::new(
                 FramebufferErrorKind::IoctlFailed,
                 &format!("Ioctl returned -1: {}", errno()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ impl Framebuffer {
         let var_screen_info = Framebuffer::get_var_screeninfo(&device)?;
         let fix_screen_info = Framebuffer::get_fix_screeninfo(&device)?;
 
-        let frame_length = (fix_screen_info.line_length * var_screen_info.yres) as usize;
+        let frame_length = (fix_screen_info.line_length * var_screen_info.yres_virtual) as usize;
         let frame = unsafe { MmapOptions::new().len(frame_length).map_mut(&device) };
         match frame {
             Ok(frame_result) => Ok(Framebuffer {


### PR DESCRIPTION
I have a framebuffer device that supports double-buffering, this is typically done by having a virtual resolution (x/yres_virtual) that's twice or more larger than the visible resolution, then you use the var's xoff/yoff values alongside the `FBIOPAN_DISPLAY` ioctl to tell the driver which portion of the screen to display at a given moment.

In order to add support for this in rust-framebuffer I had to two two changes:

* Instead of mmap'ing `line_length * yres` I remap the entire virtual space with `line_length * yres_virtual`. For device that are simple-buffered that shouldn't change anything, and for the others it will let us access the entire framebuffer through the mapping.

* I added a new method very similar to `put_var_screeninfo` with the only difference being that it calls `FBIOPAN_DISPLAY` instead.