### PR TITLE
Tweak starfield example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,4 @@ path = "examples/sierpinski/main.rs"
 
 [dev_dependencies]
 bmp = "0.1.4"
-rand = "0.6"
+rand = "0.8"


### PR DESCRIPTION
This makes a number of tweaks to the starfield example:

* The proper buffer size is calculated and used (yres_virtual rather than yres). This was causing a panic on my device.
* No longer clear every pixel before every iteration - this only clears the relevant pixels before moving the star moves. This resulted in a drastic speedup on a low-power device I was trying this on.
* Make the stars random colors
* Rename a few struct properties for easier debugging