### PR TITLE
Upgrade memmap and other dependencies mainly to avoid RUSTSEC-2020-0077

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 [dependencies]
 libc = "0.2"
 memmap2 = "0.6.1"
-errno = "0.2.7"
+errno = "0.3"
 
 [[example]]
 name = "rust-logo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 libc = "0.2"
-memmap = "0.7"
+memmap2 = "0.6.1"
 errno = "0.2.7"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "framebuffer"
 version = "0.3.1"
 authors = ["Roy van der Vegt <royvandervegt@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = """
 Basic framebuffer abstraction. Handles the necessary ioctls and mmaps the framebuffer device.
 """

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,5 @@ name = "sierpinski"
 path = "examples/sierpinski/main.rs"
 
 [dev_dependencies]
-bmp = "0.1.4"
+image = "0.24"
 rand = "0.8"

--- a/examples/mandelbrot/main.rs
+++ b/examples/mandelbrot/main.rs
@@ -1,5 +1,3 @@
-extern crate framebuffer;
-
 use framebuffer::{Framebuffer, KdMode};
 
 //Algorithm copied from:
@@ -40,7 +38,7 @@ fn main() {
         }
     }
 
-    let _ = framebuffer.write_frame(&frame);
+    framebuffer.write_frame(&frame);
 
     std::io::stdin().read_line(&mut String::new()).unwrap();
     let _ = Framebuffer::set_kd_mode(KdMode::Text).unwrap();

--- a/examples/rust-logo/main.rs
+++ b/examples/rust-logo/main.rs
@@ -1,6 +1,3 @@
-extern crate bmp;
-extern crate framebuffer;
-
 use framebuffer::{Framebuffer, KdMode};
 
 fn main() {
@@ -12,18 +9,25 @@ fn main() {
     let bytespp = framebuffer.var_screen_info.bits_per_pixel / 8;
 
     let mut frame = vec![0u8; (line_length * h) as usize];
-    let img = bmp::open("examples/rust-logo/rust-logo.bmp").unwrap();
+
+    let img = image::io::Reader::open("examples/rust-logo/rust-logo.bmp")
+        .unwrap()
+        .decode()
+        .unwrap();
 
     //Disable text mode in current tty
     let _ = Framebuffer::set_kd_mode(KdMode::Graphics).unwrap();
 
-    for offset in 0..w - img.get_width() {
-        for (x, y) in img.coordinates() {
-            let px = img.get_pixel(x, y);
-            let start_index = (y * line_length + (offset + x) * bytespp) as usize;
-            frame[start_index] = px.b;
-            frame[start_index + 1] = px.g;
-            frame[start_index + 2] = px.r;
+    for offset in 0..w - img.width() {
+        for x in 0..img.width() {
+            for y in 0..img.height() {
+                use image::GenericImageView;
+                let px: image::Rgba<u8> = img.get_pixel(x, y);
+                let start_index = (y * line_length + (offset + x) * bytespp) as usize;
+                frame[start_index] = px.0[0];
+                frame[start_index + 1] = px.0[1];
+                frame[start_index + 2] = px.0[2];
+            }
         }
 
         framebuffer.write_frame(&frame);

--- a/examples/rust-logo/main.rs
+++ b/examples/rust-logo/main.rs
@@ -26,7 +26,7 @@ fn main() {
             frame[start_index + 2] = px.r;
         }
 
-        let _ = framebuffer.write_frame(&frame);
+        framebuffer.write_frame(&frame);
     }
 
     //Reenable text mode in current tty

--- a/examples/sierpinski/main.rs
+++ b/examples/sierpinski/main.rs
@@ -1,5 +1,3 @@
-extern crate framebuffer;
-
 use framebuffer::{Framebuffer, KdMode};
 
 fn main() {
@@ -43,7 +41,7 @@ fn main() {
         }
     }
 
-    let _ = framebuffer.write_frame(&frame);
+    framebuffer.write_frame(&frame);
     let _ = std::io::stdin().read_line(&mut String::new());
     let _ = Framebuffer::set_kd_mode(KdMode::Text).unwrap();
 }

--- a/examples/starfield/main.rs
+++ b/examples/starfield/main.rs
@@ -1,6 +1,3 @@
-extern crate framebuffer;
-extern crate rand;
-
 use framebuffer::Framebuffer;
 use rand::Rng;
 
@@ -27,7 +24,7 @@ impl Starfield {
         for star in stars.iter_mut() {
             *star = Star::new_rand(w, h);
         }
-        Starfield { stars: stars }
+        Starfield { stars }
     }
 
     fn tick(&mut self, framebuffer: &Framebuffer, frame: &mut [u8]) {
@@ -35,9 +32,9 @@ impl Starfield {
         let h = framebuffer.var_screen_info.yres as usize;
 
         for star in self.stars.iter_mut() {
-            Starfield::draw_star(&star, framebuffer, frame, (0, 0, 0));
+            Starfield::draw_star(star, framebuffer, frame, (0, 0, 0));
             star.tick(w, h);
-            Starfield::draw_star(&star, framebuffer, frame, star.color);
+            Starfield::draw_star(star, framebuffer, frame, star.color);
         }
     }
 
@@ -144,7 +141,7 @@ fn main() {
 
     loop {
         starfield.tick(&framebuffer, &mut frame);
-        let _ = framebuffer.write_frame(&frame);
+        framebuffer.write_frame(&frame);
     }
 
     //Reenable text mode in current tty

--- a/examples/starfield/main.rs
+++ b/examples/starfield/main.rs
@@ -41,7 +41,12 @@ impl Starfield {
         }
     }
 
-    fn draw_star(star_data: &Star, framebuffer: &Framebuffer, frame: &mut [u8], color: (u8, u8, u8)) {
+    fn draw_star(
+        star_data: &Star,
+        framebuffer: &Framebuffer,
+        frame: &mut [u8],
+        color: (u8, u8, u8),
+    ) {
         let w = framebuffer.var_screen_info.xres as usize;
         let h = framebuffer.var_screen_info.yres as usize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!Examples can be found [here](https://github.com/Roysten/rust-framebuffer/tree/master/examples).
 
 extern crate libc;
-extern crate memmap;
+extern crate memmap2;
 
 use libc::ioctl;
 
@@ -12,7 +12,7 @@ use std::os::unix::io::AsRawFd;
 use std::path::Path;
 
 use errno::errno;
-use memmap::{MmapMut, MmapOptions};
+use memmap2::{MmapMut, MmapOptions};
 
 const FBIOGET_VSCREENINFO: libc::c_ulong = 0x4600;
 const FBIOPUT_VSCREENINFO: libc::c_ulong = 0x4601;
@@ -191,7 +191,7 @@ impl Framebuffer {
 
     ///Writes a frame to the Framebuffer.
     pub fn write_frame(&mut self, frame: &[u8]) {
-        self.frame[..].copy_from_slice(&frame[..]);
+        self.frame[..].copy_from_slice(frame);
     }
 
     ///Reads a frame from the framebuffer.
@@ -238,10 +238,7 @@ impl Framebuffer {
         }
     }
 
-    pub fn pan_display(
-        device: &File,
-        screeninfo: &VarScreeninfo,
-    ) -> Result<i32, FramebufferError> {
+    pub fn pan_display(device: &File, screeninfo: &VarScreeninfo) -> Result<i32, FramebufferError> {
         match unsafe { ioctl(device.as_raw_fd(), FBIOPAN_DISPLAY as _, screeninfo) } {
             -1 => Err(FramebufferError::new(
                 FramebufferErrorKind::IoctlFailed,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,5 @@
 //!Simple linux framebuffer abstraction.
 //!Examples can be found [here](https://github.com/Roysten/rust-framebuffer/tree/master/examples).
-
-extern crate libc;
-extern crate memmap2;
-
 use libc::ioctl;
 
 use std::fmt;


### PR DESCRIPTION
cargo-audit warn me that memmap 0.7.0 has vulnerability.

- https://rustsec.org/advisories/RUSTSEC-2020-0077

```
Crate:     memmap
Version:   0.7.0
Warning:   unmaintained
Title:     memmap is unmaintained
Date:      2020-12-02
ID:        RUSTSEC-2020-0077
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0077
Dependency tree:
memmap 0.7.0
└── framebuffer 0.3.1
```